### PR TITLE
[#13]  [Front] 開催報告記事一覧の API 連携 #13 

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,10 +5,17 @@ import AboutCoderDojo from '@/components/pages/home/AboutCoderDojo/AboutCoderDoj
 import Access from '@/components/pages/home/Access/Access';
 import EventReport from '@/components/pages/home/EventReport/EventReport';
 import getNextEvents from '@/features/nextEvent/api/getNextEvents';
+import getReports from '@/features/reports/api/getReports';
 
 export default async function Home() {
   // 次回開催イベント一覧を取得
   const nextEvents = await getNextEvents();
+
+  // 開催報告一覧を取得
+  const reports = await getReports();
+
+  // @TODO: 一旦開催報告一覧をログに出力
+  console.log(reports);
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-between">

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,0 +1,23 @@
+import getReports from '@/features/reports/api/getReports';
+
+export default async function ForFirstTimers() {
+  // 開催報告一覧を取得
+  const reports = await getReports();
+
+  // @TODO: 一旦開催報告一覧をログに出力
+  console.log(reports);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-between">
+      {/* Contents */}
+      <div className="mx-auto w-screen max-w-4xl px-8 py-20 max-sm:pt-14 sm:p-12 sm:py-20 md:p-24">
+        {/* 初めて参加される方へ */}
+        <div className="pb-5">
+          <h2 className="text-center text-2xl font-bold">開催報告</h2>
+        </div>
+
+        {/* @TODO: 開催報告一覧 */}
+      </div>
+    </main>
+  );
+}

--- a/src/features/reports/api/getReports.ts
+++ b/src/features/reports/api/getReports.ts
@@ -1,0 +1,18 @@
+import { microCMS } from '@/libs/microCMSClient';
+import excludeKeys from '@/utils/excludeKeys';
+
+import { reportKeys } from '../types/keys';
+
+import type { Report } from '../types';
+
+export default async function getNextEvents() {
+  return await microCMS.getList<Report>({
+    endpoint: 'reports',
+    customRequestInit: {
+      next: { revalidate: 60 },
+    },
+    queries: {
+      fields: excludeKeys<Report>(reportKeys, 'content'),
+    },
+  });
+}

--- a/src/features/reports/types/index.d.ts
+++ b/src/features/reports/types/index.d.ts
@@ -1,0 +1,9 @@
+import { type MicroCMSDate } from 'microcms-js-sdk';
+
+export type Report = {
+  id: string;
+  title: string;
+  content: string;
+  summary: string;
+  originalCreatedAt?: string;
+} & MicroCMSDate;

--- a/src/features/reports/types/keys/index.ts
+++ b/src/features/reports/types/keys/index.ts
@@ -1,0 +1,13 @@
+import type { Report } from '../';
+
+export const reportKeys: Array<keyof Report> = [
+  'id',
+  'createdAt',
+  'updatedAt',
+  'publishedAt',
+  'revisedAt',
+  'title',
+  'content',
+  'summary',
+  'originalCreatedAt',
+];

--- a/src/utils/excludeKeys.ts
+++ b/src/utils/excludeKeys.ts
@@ -1,0 +1,14 @@
+export default function excludeKeys<T>(
+  keys: Array<keyof T>,
+  exclude: string,
+): string {
+  const excludedKeys = exclude.split(',');
+
+  // 除外されたキー以外をフィルタリング
+  const filteredKeys = keys.filter(
+    (key) => !excludedKeys.includes(key as string),
+  );
+
+  // カンマ区切りで返却
+  return filteredKeys.join(',');
+}


### PR DESCRIPTION
## 📝 関連する課題 / Related Issues

- #13

## ⛏ 変更内容 / Details of Changes

### utils 関数の実装

- 型に基づき、特定の key を除外する utils 関数を実装しました [ca234b4ad9e16953f119cae26d4232556b361c3a]

### 型 (及び keys) の定義

- report(s) に関連する型 (及び key 配列) を定義しました [8f1f0a90699ed44b1b90ba7652ca03bf57f9eb0a]

### API 連携

- microcms から開催報告一覧 API 呼び出しを行う関数を実装しました [97256f8bd3aec6dc745e71e9f5f854056ad805d9]
- HOME ページにて開催報告一覧を取得してログに出力するまでを実装しました [ed14c1adaa847542c360f237c411adc686642b79]
- 開催報告ページ (仮) にて開催報告一覧を取得してログに出力するまでを実装しました [153569b283303528147ed5a625a6a46907ea95b0]

## 📸 スクリーンショット / Screenshots

<details>
<summary>スクリーンショット一覧</summary>

### 開催報告一覧ログ出力

<img width="1532" alt="image" src="https://github.com/user-attachments/assets/985da670-7ea4-4be7-a6b3-94e3be9629bb">

</details>

## 💬 備考 / Remarks

- ESLint 等のエラー、ワーニングは修正済みです。

以上になります。
