### PR TITLE
[Front] 各種ページのタイトルのコンポーネント (PageHeading) の実装

### DIFF
--- a/src/app/for-first-timers/page.tsx
+++ b/src/app/for-first-timers/page.tsx
@@ -2,6 +2,7 @@ import NotAProgrammingSchool from '@/components/pages/for-first-timers/NotAProgr
 import MemberAtCoderDojo from '@/components/pages/for-first-timers/MemberAtCoderDojo/MemberAtCoderDojo';
 import ForUnsureFriends from '@/components/pages/for-first-timers/ForUnsureFriends/ForUnsureFriends';
 import ForThoseInterested from '@/components/pages/for-first-timers/ForThoseInterested/ForThoseInterested';
+import PageHeading from '@/components/common/PageHeading/PageHeading';
 
 export default function ForFirstTimers() {
   return (
@@ -10,9 +11,7 @@ export default function ForFirstTimers() {
       <div className="mx-auto w-screen max-w-4xl px-8 py-20 max-sm:pt-14 sm:p-12 sm:py-20 md:p-24">
         {/* 初めて参加される方へ */}
         <div className="pb-5">
-          <h2 className="text-center text-2xl font-bold">
-            初めて参加される方へ
-          </h2>
+          <PageHeading label="初めて参加される方へ" />
         </div>
 
         {/* CoderDojoはプログラミング教室ではありません */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import Access from '@/components/pages/home/Access/Access';
 import EventReport from '@/components/pages/home/EventReport/EventReport';
 import getNextEvents from '@/features/nextEvent/api/getNextEvents';
 import getReports from '@/features/reports/api/getReports';
+import PageHeading from '@/components/common/PageHeading/PageHeading';
 
 export default async function Home() {
   // 次回開催イベント一覧を取得
@@ -27,9 +28,10 @@ export default async function Home() {
         {/* マイクラ部お知らせ (First view news) */}
         {/* @TODO: md から読み込みでも良いかも, もしくは API */}
         <section className="mb-16 sm:mb-20">
-          <h2 className="mb-4 text-center text-2xl font-bold">
-            CoderDojo八戸に「マイクラ部」ができました!!
-          </h2>
+          <PageHeading
+            label="CoderDojo八戸に「マイクラ部」ができました!!"
+            className="mb-4"
+          />
           <p className="mb-2.5 text-left text-sm leading-6">
             マイクラ大好きなみんな!マイクラだけをやる「マイクラ部」に参加してみませんか!?
           </p>

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,3 +1,4 @@
+import PageHeading from '@/components/common/PageHeading/PageHeading';
 import getReports from '@/features/reports/api/getReports';
 
 export default async function ForFirstTimers() {
@@ -13,7 +14,7 @@ export default async function ForFirstTimers() {
       <div className="mx-auto w-screen max-w-4xl px-8 py-20 max-sm:pt-14 sm:p-12 sm:py-20 md:p-24">
         {/* 初めて参加される方へ */}
         <div className="pb-5">
-          <h2 className="text-center text-2xl font-bold">開催報告</h2>
+          <PageHeading label="開催報告" />
         </div>
 
         {/* @TODO: 開催報告一覧 */}

--- a/src/components/common/PageHeading/PageHeading.tsx
+++ b/src/components/common/PageHeading/PageHeading.tsx
@@ -1,0 +1,16 @@
+import React, { HTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+type PageHeadingProps = {
+  label: string;
+} & HTMLAttributes<HTMLHeadingElement>;
+
+const PageHeading = ({ label, className }: PageHeadingProps) => {
+  return (
+    <h2 className={twMerge('text-center text-2xl font-bold', className)}>
+      {label}
+    </h2>
+  );
+};
+
+export default PageHeading;


### PR DESCRIPTION
## 📝 関連する課題 / Related Issues

- #14 

## ⛏ 変更内容 / Details of Changes

### コンポーネントの実装
- コンポーネントファイル PageHeading.tsx ファイルの追加 [e638a7c97aaa956dfe195ef3fb75135f9fc36972]
- ページ見出しのコンポーネントの実装 [b9046bd6a349da63c6736e6147bbc4f85f10ded6]

### コンポーネントの呼び出し
- 見出しをコンポーネントを使用して表示するように修正 [986b8d8496e8e6ec220c304af82a8a4e1f5cc182]

## 💬 備考 / Remarks

- 特にありません

@yuta-sksn 
お疲れ様です。
実装完了致しましたので、PR作成致しました！
ご確認よろしくお願いいたします！