### PR TITLE
[Front] 開催報告一覧を表示するコンポーネントの実装

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.microcms-assets.io',
+        port: '',
+        pathname: '/assets/**',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,9 +14,6 @@ export default async function Home() {
   // 開催報告一覧を取得
   const reports = await getReports();
 
-  // @TODO: 一旦開催報告一覧をログに出力
-  console.log(reports);
-
   return (
     <main className="flex min-h-screen flex-col items-center justify-between">
       {/* KV */}
@@ -60,8 +57,7 @@ export default async function Home() {
         <Access className="mb-16" />
 
         {/* 開催報告 */}
-        {/* @TODO: API 連携 */}
-        <EventReport />
+        <EventReport reports={reports.contents} />
       </div>
     </main>
   );

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -1,11 +1,10 @@
+import FadeInOnScrollContainer from '@/components/common/FadeInOnScrollContainer/FadeInOnScrollContainer';
+import ReportList from '@/components/common/ReportList/ReportList';
 import getReports from '@/features/reports/api/getReports';
 
 export default async function ForFirstTimers() {
   // 開催報告一覧を取得
   const reports = await getReports();
-
-  // @TODO: 一旦開催報告一覧をログに出力
-  console.log(reports);
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-between">
@@ -16,7 +15,10 @@ export default async function ForFirstTimers() {
           <h2 className="text-center text-2xl font-bold">開催報告</h2>
         </div>
 
-        {/* @TODO: 開催報告一覧 */}
+        {/* 開催報告一覧 */}
+        <FadeInOnScrollContainer>
+          <ReportList reports={reports.contents} className="mt-5" />
+        </FadeInOnScrollContainer>
       </div>
     </main>
   );

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -3,7 +3,7 @@ import FadeInOnScrollContainer from '@/components/common/FadeInOnScrollContainer
 import ReportList from '@/components/common/ReportList/ReportList';
 import getReports from '@/features/reports/api/getReports';
 
-export default async function ForFirstTimers() {
+export default async function Reports() {
   // 開催報告一覧を取得
   const reports = await getReports();
 

--- a/src/components/common/FadeInOnScrollContainer/FadeInOnScrollContainer.tsx
+++ b/src/components/common/FadeInOnScrollContainer/FadeInOnScrollContainer.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import React, { HTMLAttributes } from 'react';
+
+import useFadeInOnScroll from '@/hooks/useFadeInOnScroll';
+
+type FadeInOnScrollContainerProps = HTMLAttributes<HTMLElement>;
+
+const FadeInOnScrollContainer = ({
+  children,
+}: FadeInOnScrollContainerProps) => {
+  const { ref: divRef, fadeInClass } = useFadeInOnScroll<HTMLDivElement>();
+
+  return (
+    <div ref={divRef} className={fadeInClass}>
+      {children}
+    </div>
+  );
+};
+
+export default FadeInOnScrollContainer;

--- a/src/components/common/ReportCard/ReportCard.tsx
+++ b/src/components/common/ReportCard/ReportCard.tsx
@@ -1,0 +1,66 @@
+import React, { HTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
+import Image from 'next/image';
+import Link from 'next/link';
+
+import { formatDate } from '@/utils/formatDate';
+import { extractFirstImageUrl } from '@/utils/extractFirstImageUrl';
+
+import type { Report } from '@/features/reports/types';
+
+const DEFAULT_LOGO_IMAGE = '/images/logo.jpg';
+
+type ReportCardProps = {
+  report: Report;
+} & HTMLAttributes<HTMLElement>;
+
+const ReportCard = ({ report, className }: ReportCardProps) => {
+  // サムネイル
+  const thumbnailUrl =
+    extractFirstImageUrl(report.content) || DEFAULT_LOGO_IMAGE;
+  // サムネイルが存在しない場合の Class
+  const noThumbnailTwClasses =
+    thumbnailUrl === DEFAULT_LOGO_IMAGE ? 'w-3/4 h-auto object-contain' : '';
+  // 投稿日時
+  const publishedAt = report.originalCreatedAt || report.publishedAt;
+
+  return (
+    <article className={twMerge('', className)}>
+      <Link href={`/reports/${report.id}`}>
+        {/* サムネイル画像 */}
+        {/* PC高さ最大値: 138.331px */}
+        <div className="relative mb-3 flex aspect-[4/3] w-full justify-center overflow-hidden border border-gray-200 md:max-h-[165.998px]">
+          <Image
+            src={thumbnailUrl}
+            alt={`${report.title} thumbnail`}
+            width="720"
+            height="480"
+            className={twMerge(
+              'block h-auto w-full object-cover md:max-h-[165.998px]',
+              noThumbnailTwClasses,
+            )}
+            loading="lazy"
+          />
+        </div>
+
+        {/* 投稿概要 */}
+        <div>
+          {/* 投稿日時 */}
+          <time dateTime={publishedAt} className="text-xs text-gray-400">
+            {formatDate(publishedAt || '')}
+          </time>
+          {/* タイトル */}
+          <h3 className="mb-2 mt-1.5 line-clamp-2 text-[0.94rem]">
+            {report.title}
+          </h3>
+          {/* サマリー */}
+          <p className="line-clamp-2 text-[0.8rem] max-sm:leading-[1.05rem] sm:text-sm">
+            {report.summary}
+          </p>
+        </div>
+      </Link>
+    </article>
+  );
+};
+
+export default ReportCard;

--- a/src/components/common/ReportList/ReportList.tsx
+++ b/src/components/common/ReportList/ReportList.tsx
@@ -1,0 +1,29 @@
+import React, { HTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import ReportCard from '../ReportCard/ReportCard';
+
+import type { Report } from '@/features/reports/types';
+
+type ReportListProps = {
+  reports: Report[];
+} & HTMLAttributes<HTMLUListElement>;
+
+const ReportList = ({ reports, className }: ReportListProps) => {
+  return (
+    <ul
+      className={twMerge(
+        'grid grid-cols-1 gap-5 max-sm:gap-10 sm:grid-cols-2 md:grid-cols-3',
+        className,
+      )}
+    >
+      {reports.map((report) => (
+        <li key={report.id}>
+          <ReportCard report={report} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default ReportList;

--- a/src/components/pages/home/EventReport/EventReport.tsx
+++ b/src/components/pages/home/EventReport/EventReport.tsx
@@ -6,15 +6,23 @@ import { twMerge } from 'tailwind-merge';
 import SectionTitle from '@/components/common/SectionTitle/SectionTitle';
 import ButtonLink from '@/components/common/ButtonLink/ButtonLink';
 import useFadeInOnScroll from '@/hooks/useFadeInOnScroll';
+import ReportList from '@/components/common/ReportList/ReportList';
 
-type EventReportProps = Record<string, unknown> & HTMLAttributes<HTMLElement>;
+import type { Report } from '@/features/reports/types';
 
-const EventReport = ({ className }: EventReportProps) => {
+type EventReportProps = {
+  reports: Report[];
+} & HTMLAttributes<HTMLElement>;
+
+const EventReport = ({ reports, className }: EventReportProps) => {
   const { ref: sectionRef, fadeInClass } = useFadeInOnScroll();
 
   return (
     <section ref={sectionRef} className={twMerge(fadeInClass, className)}>
       <SectionTitle title="開催報告" className="mb-6" />
+
+      <ReportList reports={reports} className="mb-10" />
+
       <div className="flex justify-center">
         <ButtonLink href="/reports" className="!w-64">
           もっと見る

--- a/src/features/reports/api/getReports.ts
+++ b/src/features/reports/api/getReports.ts
@@ -1,7 +1,4 @@
 import { microCMS } from '@/libs/microCMSClient';
-import excludeKeys from '@/utils/excludeKeys';
-
-import { reportKeys } from '../types/keys';
 
 import type { Report } from '../types';
 
@@ -12,7 +9,7 @@ export default async function getNextEvents() {
       next: { revalidate: 60 },
     },
     queries: {
-      fields: excludeKeys<Report>(reportKeys, 'content'),
+      // fields: excludeKeys<Report>(reportKeys, 'content'),
     },
   });
 }

--- a/src/utils/excludeKeys.ts
+++ b/src/utils/excludeKeys.ts
@@ -1,7 +1,12 @@
-export default function excludeKeys<T>(
-  keys: Array<keyof T>,
-  exclude: string,
-): string {
+/**
+ * 指定したキーを除外して残りのキーをカンマ区切りの文字列として返す関数
+ *
+ * @template T - オブジェクトの型
+ * @param keys - フィルタリング対象となるキーの配列
+ * @param exclude - 除外したいキーをカンマ区切りの文字列で指定
+ * @returns 除外されたキーを除いた、残りのキーをカンマ区切りにした文字列
+ */
+export function excludeKeys<T>(keys: Array<keyof T>, exclude: string): string {
   const excludedKeys = exclude.split(',');
 
   // 除外されたキー以外をフィルタリング

--- a/src/utils/extractFirstImageUrl.ts
+++ b/src/utils/extractFirstImageUrl.ts
@@ -1,0 +1,11 @@
+/**
+ * HTML 文字列から最初の画像の URL を抽出する関数
+ *
+ * @param html - 画像を含む HTML 文字列
+ * @returns 最初の画像の URL。画像が存在しない場合は undefined を返す
+ */
+export function extractFirstImageUrl(html: string): string | undefined {
+  const imgRegex = /<img[^>]+src="([^">]+)"/;
+  const match = html.match(imgRegex);
+  return match ? match[1] : undefined;
+}

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,30 @@
+/**
+ * ISO 8601形式の文字列を YYYY/MM/DD HH:MM:SS にフォーマットする関数
+ *
+ * @param isoString - ISO 8601形式の日付文字列
+ * @returns フォーマットされた日付文字列
+ * @throws Error - 無効な日付が入力された場合にエラーをスロー
+ */
+export function formatDate(
+  isoString: string,
+  isSecondsVisible = false,
+): string {
+  if (typeof isoString !== 'string') {
+    throw new Error('無効な日付形式です');
+  }
+  const date: Date = new Date(isoString);
+
+  if (isNaN(date.getTime())) {
+    throw new Error('無効な日付形式です');
+  }
+
+  const year: string = date.getFullYear().toString();
+  const month: string = (date.getMonth() + 1).toString().padStart(2, '0');
+  const day: string = date.getDate().toString().padStart(2, '0');
+
+  const hours: string = date.getHours().toString().padStart(2, '0');
+  const minutes: string = date.getMinutes().toString().padStart(2, '0');
+  const seconds: string = date.getSeconds().toString().padStart(2, '0');
+
+  return `${year}.${month}.${day} ${hours}:${minutes}${isSecondsVisible ? `:${seconds}` : ''}`;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,9 @@ const config: Config = {
         'gradient-conic':
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      aspectRatio: {
+        '4/3': '4 / 3',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 📝 関連する課題 / Related Issues

- #16

## ⛏ 変更内容 / Details of Changes

### PJ の設定

- images.microcms-assets.io を next/image の remotePatterns に追加しました [3a2fa2370589fa395a340cec036eca423851bb54]
- tailwind css にアスペクト比の拡張を追加しました [753e4d2fb707bed3c5f0d2ab8eb898407576cbf2]


### utils 関数の実装

- 日時をフォーマットする utils 関数を実装しました [6f3e050babbb12329dc4e7cfaeba594e2de7fe41]
- HTML 文字列から最初の画像の URL を抽出する utils 関数を実装しました [de2e5cf71a06dbfe36d137e7a450bea554110717]

### api 呼び出し処理の修正

- 全てのフィールドを取ってくるように修正 (件数やオーダーは後ほど) しました [604669ff75ff34359b09b9091cf0bf8c215cf041]

### コンポーネントの実装 / 修正

- 開催報告一覧のカード部分表示コンポーネントの実装を行いました [62516cbf82f8a6af2ce6c6ffefcfc77684e8ff38]
- Report[] 配列を元に開催報告一覧を表示するコンポーネントを実装しました [22c252935605faec54b1e5a48ce54c8f0dc5f0d2]
- スクロールフェードインを children に対して行うコンポーネントを実装しました [a60c0c9f65ceceeb0aa9ec15493e48ea8e8db306]
- EventReport (開催報告セクション) に ReportList を追加しました [7f98eb0f144fde91f2ace4531bfba99e075bce29]

### ページ側の修正 

- HOME ページの開催報告の API 連携を実装しました [5e9a61ca2711256b13b8166bc2f35178e0001119]
- 開催報告ページの一覧 API 連携を実装しました [25dc42132395db918b55220f43ad276f0b7a1eb1]

### その他修正

- コメントの追記を行いました [9d06bf1d228d593c7dd602322439daac7e68c821]
- function 名をページに合わせて修正しました [13a992510321600d48b5041b6d8872a3e0220f16]

## 📸 スクリーンショット / Screenshots

<details>
<summary>スクリーンショット一覧</summary>

### PC サイズ

<img width="1532" alt="image" src="https://github.com/user-attachments/assets/cac9d2a5-d83a-4e57-b516-d452d7ca0cfc">

<img width="1532" alt="image" src="https://github.com/user-attachments/assets/9a5eb3bb-1fd9-4867-a088-ea73c1a34e45">

### SP サイズ

![image](https://github.com/user-attachments/assets/860a8714-974a-41f4-a063-2887be29200c)

![image](https://github.com/user-attachments/assets/7bc08055-1a23-4935-a4d1-10aa502c8c85)

</details>

## 💬 備考 / Remarks

- 一旦、オーダーや表示件数制御、ページネーションは別タスクに切り出します。

以上になります。