### PR TITLE
feat: コンポーネントファイル MentorList.tsx の追加

### DIFF
--- a/src/app/mentors/page.tsx
+++ b/src/app/mentors/page.tsx
@@ -16,17 +16,19 @@ export default async function Mentors() {
         <div className="pb-5">
           <PageHeading label="サポートメンバー" className="mb-4" />
         </div>
+
+        {/* チャンピオン（主催者）一覧 */}
         <FadeInOnScrollContainer>
-          {/* チャンピオン（主催者）一覧 */}
           <SectionTitle title="チャンピオン（主催者）" className="mb-6" />
           <MentorList
             mentors={mentors.contents}
             position="champion"
-            className="mt-5 mb-12 sm:mt-10 sm:mb-20 "
+            className="mb-12 mt-5 sm:mb-20 sm:mt-10"
           />
         </FadeInOnScrollContainer>
+
+        {/* メンター一覧 */}
         <FadeInOnScrollContainer>
-          {/* メンター一覧 */}
           <SectionTitle title="メンター" className="mb-6" />
           <MentorList
             mentors={mentors.contents}

--- a/src/app/mentors/page.tsx
+++ b/src/app/mentors/page.tsx
@@ -1,7 +1,40 @@
+import PageHeading from '@/components/common/PageHeading/PageHeading';
+import SectionTitle from '@/components/common/SectionTitle/SectionTitle';
 import getMentors from '@/features/mentors/api/getMentors';
+import MentorList from '@/components/common/MentorList/MentorList';
+import FadeInOnScrollContainer from '@/components/common/FadeInOnScrollContainer/FadeInOnScrollContainer';
 
 export default async function Mentors() {
   // サポートメンバー一覧を取得
   const mentors = await getMentors();
 
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-between">
+      {/* Contents */}
+      <div className="mx-auto w-screen max-w-4xl px-8 py-20 max-sm:pt-14 sm:p-12 sm:py-20 md:p-24">
+        {/* サポートメンバー */}
+        <div className="pb-5">
+          <PageHeading label="サポートメンバー" className="mb-4" />
+        </div>
+        <FadeInOnScrollContainer>
+          {/* チャンピオン（主催者）一覧 */}
+          <SectionTitle title="チャンピオン（主催者）" className="mb-6" />
+          <MentorList
+            mentors={mentors.contents}
+            position="champion"
+            className="mt-5 mb-12 sm:mt-10 sm:mb-20 "
+          />
+        </FadeInOnScrollContainer>
+        <FadeInOnScrollContainer>
+          {/* メンター一覧 */}
+          <SectionTitle title="メンター" className="mb-6" />
+          <MentorList
+            mentors={mentors.contents}
+            position="mentor"
+            className="my-5"
+          />
+        </FadeInOnScrollContainer>
+      </div>
+    </main>
+  );
 }

--- a/src/app/mentors/page.tsx
+++ b/src/app/mentors/page.tsx
@@ -4,6 +4,4 @@ export default async function Mentors() {
   // サポートメンバー一覧を取得
   const mentors = await getMentors();
 
-  // @TODO: 一時的にサポートメンバー一覧をログに出力
-  console.log(JSON.stringify(mentors, null, 2));
 }

--- a/src/components/common/MentorList/MentorList.tsx
+++ b/src/components/common/MentorList/MentorList.tsx
@@ -2,10 +2,10 @@ import React, { HTMLAttributes } from 'react';
 
 import MentorMediaObject from '../MentorMediaObject/MentorMediaObject';
 
-import type { Mentors } from '@/features/mentors/types';
+import type { Mentor } from '@/features/mentors/types';
 
 type MentorListProps = {
-  mentors: Mentors[];
+  mentors: Mentor[];
   position: 'champion' | 'mentor';
 } & HTMLAttributes<HTMLUListElement>;
 

--- a/src/components/common/MentorList/MentorList.tsx
+++ b/src/components/common/MentorList/MentorList.tsx
@@ -1,0 +1,28 @@
+import React, { HTMLAttributes } from 'react';
+
+import MentorMediaObject from '../MentorMediaObject/MentorMediaObject';
+
+import type { Mentors } from '@/features/mentors/types';
+
+type MentorListProps = {
+  mentors: Mentors[];
+  position: 'champion' | 'mentor';
+} & HTMLAttributes<HTMLUListElement>;
+
+const MentorList = ({ mentors, position, className }: MentorListProps) => {
+  const filteredMentors = mentors.filter((mentor) =>
+    mentor.position.includes(position),
+  );
+
+  return (
+    <ul className={className}>
+      {filteredMentors.map((mentor) => (
+        <li key={mentor.id}>
+          <MentorMediaObject mentor={mentor} />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default MentorList;

--- a/src/components/common/MentorMediaObject/MentorMediaObject.tsx
+++ b/src/components/common/MentorMediaObject/MentorMediaObject.tsx
@@ -1,15 +1,14 @@
+import React, { HTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
 import Image from 'next/image';
 
-import React, { HTMLAttributes } from 'react';
-
-import type { Mentor } from '@/features/mentors/types';
-import { twMerge } from 'tailwind-merge';
+import { Mentor } from '@/features/mentors/types';
 
 type MentorMediaObjectProps = {
   mentor: Mentor;
 } & HTMLAttributes<HTMLElement>;
 
-const MentorMediaObject = ({ mentor, className }: MentorMediaObjectProps) => {
+const MentorMediaObject = ({ mentor }: MentorMediaObjectProps) => {
   const overviewTextClasses = 'text-sm leading-6 text-left mb-2.5 last:mb-0';
 
   return (
@@ -32,7 +31,7 @@ const MentorMediaObject = ({ mentor, className }: MentorMediaObjectProps) => {
         </p>
         <div
           dangerouslySetInnerHTML={{
-            __html: mentor.description
+            __html: mentor.description,
           }}
           className={overviewTextClasses}
         />

--- a/src/components/common/MentorMediaObject/MentorMediaObject.tsx
+++ b/src/components/common/MentorMediaObject/MentorMediaObject.tsx
@@ -2,11 +2,11 @@ import Image from 'next/image';
 
 import React, { HTMLAttributes } from 'react';
 
-import type { Mentors } from '@/features/mentors/types';
+import type { Mentor } from '@/features/mentors/types';
 import { twMerge } from 'tailwind-merge';
 
 type MentorMediaObjectProps = {
-  mentor: Mentors;
+  mentor: Mentor;
 } & HTMLAttributes<HTMLElement>;
 
 const MentorMediaObject = ({ mentor, className }: MentorMediaObjectProps) => {

--- a/src/components/common/MentorMediaObject/MentorMediaObject.tsx
+++ b/src/components/common/MentorMediaObject/MentorMediaObject.tsx
@@ -1,0 +1,44 @@
+import Image from 'next/image';
+
+import React, { HTMLAttributes } from 'react';
+
+import type { Mentors } from '@/features/mentors/types';
+import { twMerge } from 'tailwind-merge';
+
+type MentorMediaObjectProps = {
+  mentor: Mentors;
+} & HTMLAttributes<HTMLElement>;
+
+const MentorMediaObject = ({ mentor, className }: MentorMediaObjectProps) => {
+  const overviewTextClasses = 'text-sm leading-6 text-left mb-2.5 last:mb-0';
+
+  return (
+    <div className="mb-8 flex flex-col gap-8 md:flex-row">
+      {/* バナー */}
+      <div className="flex-1">
+        <Image
+          src={mentor.image.url}
+          alt={mentor.name}
+          width={mentor.image.width}
+          height={mentor.image.height}
+          className="!w-full md:w-[340px]"
+          loading="lazy"
+        />
+      </div>
+      {/* 説明テキスト */}
+      <div className="flex-1">
+        <p className={twMerge(overviewTextClasses, 'font-bold')}>
+          {mentor.name}
+        </p>
+        <div
+          dangerouslySetInnerHTML={{
+            __html: mentor.description
+          }}
+          className={overviewTextClasses}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MentorMediaObject;

--- a/src/features/mentors/api/getMentors.ts
+++ b/src/features/mentors/api/getMentors.ts
@@ -1,9 +1,9 @@
 import { microCMS } from '@/libs/microCMSClient';
 
-import type { Mentors } from '../types';
+import type { Mentor } from '../types';
 
 export default async function getMentors() {
-  return await microCMS.getList<Mentors>({
+  return await microCMS.getList<Mentor>({
     endpoint: 'mentors',
     customRequestInit: {
       next: { revalidate: 60 },

--- a/src/features/mentors/types/index.d.ts
+++ b/src/features/mentors/types/index.d.ts
@@ -5,6 +5,10 @@ export type Mentors = {
   position: ('champion' | 'mentor')[];
   name: string;
   description: string;
-  image: string;
+  image: {
+    url: string;
+    height: number;
+    width: number;
+  };
   order?: number;
 } & MicroCMSDate;

--- a/src/features/mentors/types/index.d.ts
+++ b/src/features/mentors/types/index.d.ts
@@ -1,6 +1,6 @@
 import { type MicroCMSDate } from 'microcms-js-sdk';
 
-export type Mentors = {
+export type Mentor = {
   id: string;
   position: ('champion' | 'mentor')[];
   name: string;


### PR DESCRIPTION
## 📝 関連する課題 / Related Issues

- #20 

## ⛏ 変更内容 / Details of Changes

### コンポーネントファイルの追加
- コンポーネントファイル MentorList.tsx の追加 [0ef787acc7d71633ce5e7c0c0d1634e1da122c91]
- コンポーネントファイル MentorMediaObject.tsx の追加 [43adf25e6f9f8b4766827df6bcaa43ec354fc213]

### Mentors の型修正
- Mentors の image の型修正 [c98ac0340049bcc7871a4daf7691401e85968cdf]

### コンポーネント実装
- ポートメンバーのメディアオブジェクト部分表示コンポーネントの実装 [4cf8cce3a1440b5ca1f9bcb8b37bae1dc830880d]
- Mentors[] 配列を元にサポートメンバー一覧を表示するコンポーネントの実装 [854be994195ae5e3c71985588038fdb7120b7dec]

### サポートメンバーページ
- ログ出力処理の削除 [73078274f3ef064b4f233a5efdf96d4021498ad8]
- サポートメンバー画面の実装 [9b3283aa5f3e0daf5dc57a6622c6dbfd2b0025c1]

## 💬 備考 / Remarks

- `MentorList` を一回呼び出すだけで、主催者とメンターの両方を表示できないか考えたのですが、
案と方法が確立出来なかったため、`MentorList` を主催者表示時とメンター表示時でそれぞれ呼び出すようにし、
引数に `position`  の値を渡し、MentorList 側で `filter` を用いて処理を切り分けるようにしました。
他の方法やアドバイス等ありましたらよろしくお願いいたします。

@yuta-sksn 
お疲れ様です！
こちら実装が完了致しましたので、PR 作成致しました！
ご確認よろしくお願いいたします！