### PR TITLE
[#31] [Front] 開催報告詳細ページの実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write './src/**/*.{ts,tsx}'"
   },
   "dependencies": {
+    "html-react-parser": "^5.1.16",
     "microcms-js-sdk": "^3.1.2",
     "next": "14.2.5",
     "react": "^18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      html-react-parser:
+        specifier: ^5.1.16
+        version: 5.1.16(@types/react@18.3.3)(react@18.3.1)
       microcms-js-sdk:
         specifier: ^3.1.2
         version: 3.1.2
@@ -810,6 +813,19 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -825,6 +841,10 @@ packages:
   enhanced-resolve@5.17.1:
     resolution: {integrity: sha512-LMHl3dXhTcfv8gM4kEzIUeTQ+7fpdA0l2tUf34BddXPkz2A5xJ5L/Pchd5BL6rdccM9QGvu0sWZzK1Z1t4wwyg==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -1195,9 +1215,24 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
+  html-dom-parser@5.0.10:
+    resolution: {integrity: sha512-GwArYL3V3V8yU/mLKoFF7HlLBv80BZ2Ey1BzfVNRpAci0cEKhFHI/Qh8o8oyt3qlAMLlK250wsxLdYX4viedvg==}
+
+  html-react-parser@5.1.16:
+    resolution: {integrity: sha512-OtVPEQRwa4eelyMbHmUfMSw5VwJsVGSVsfa8I+M8xuV87n91cF3PHpvT/z0Frf1uG34atqh3dxgjaGIsmqVsRA==}
+    peerDependencies:
+      '@types/react': 0.14 || 15 || 16 || 17 || 18
+      react: 0.14 || 15 || 16 || 17 || 18
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   html-tags@3.3.1:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
     engines: {node: '>=8'}
+
+  htmlparser2@9.1.0:
+    resolution: {integrity: sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -1226,6 +1261,9 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  inline-style-parser@0.2.3:
+    resolution: {integrity: sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g==}
 
   internal-slot@1.0.7:
     resolution: {integrity: sha512-NGnrKwXzSms2qUUih/ILZ5JBqNTSa1+ZmP6flaIp6KmSElgE9qdndzS3cqjrDovwFdmwsGsLdeFgB6suw+1e9g==}
@@ -1829,6 +1867,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-property@2.0.2:
+    resolution: {integrity: sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==}
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -2035,6 +2076,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.14:
+    resolution: {integrity: sha512-+FGNddHGLPY4NOPneEEdFj8dIy+oV4mHGrPZpB38P+YXrCAG9mp70dbcsAWnM8BFZULkJRvMqD0CXRjZLOYJFA==}
+
+  style-to-object@1.0.7:
+    resolution: {integrity: sha512-uSjr59G5u6fbxUfKbb8GcqMGT3Xs9v5IbPkjb0S16GyOeBLAzSRK0CixBv5YrYvzO6TDLzIS6QCn78tkqWngPw==}
 
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
@@ -2980,6 +3027,24 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.1.0:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   eastasianwidth@0.2.0: {}
 
   emoji-regex@8.0.0: {}
@@ -2994,6 +3059,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
+
+  entities@4.5.0: {}
 
   env-paths@2.2.1: {}
 
@@ -3526,7 +3593,29 @@ snapshots:
 
   help-me@5.0.0: {}
 
+  html-dom-parser@5.0.10:
+    dependencies:
+      domhandler: 5.0.3
+      htmlparser2: 9.1.0
+
+  html-react-parser@5.1.16(@types/react@18.3.3)(react@18.3.1):
+    dependencies:
+      domhandler: 5.0.3
+      html-dom-parser: 5.0.10
+      react: 18.3.1
+      react-property: 2.0.2
+      style-to-js: 1.1.14
+    optionalDependencies:
+      '@types/react': 18.3.3
+
   html-tags@3.3.1: {}
+
+  htmlparser2@9.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
 
   ieee754@1.2.1: {}
 
@@ -3549,6 +3638,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  inline-style-parser@0.2.3: {}
 
   internal-slot@1.0.7:
     dependencies:
@@ -4078,6 +4169,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-property@2.0.2: {}
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4336,6 +4429,14 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.14:
+    dependencies:
+      style-to-object: 1.0.7
+
+  style-to-object@1.0.7:
+    dependencies:
+      inline-style-parser: 0.2.3
 
   styled-jsx@5.1.1(react@18.3.1):
     dependencies:

--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -23,3 +23,19 @@ body {
     text-wrap: balance;
   }
 }
+
+.mc-content-p {
+  @apply text-sm leading-7 max-sm:leading-6;
+
+  a {
+    @apply text-blue-400 hover:opacity-70;
+  }
+}
+
+.mc-content-h2 {
+  @apply my-8 text-2xl max-sm:my-4 max-sm:text-xl;
+}
+
+.mc-content-figure {
+  @apply my-10;
+}

--- a/src/app/reports/[id]/page.tsx
+++ b/src/app/reports/[id]/page.tsx
@@ -1,0 +1,48 @@
+import PageHeading from '@/components/common/PageHeading/PageHeading';
+import ReportContent from '@/components/pages/reports/ReportContent/ReportContent';
+import getReport from '@/features/report/api/getReport';
+import getReports from '@/features/report/api/getReports';
+import { Report } from '@/features/report/types';
+import { formatDate } from '@/utils/formatDate';
+
+export async function generateStaticParams() {
+  // 開催報告を取得
+  const reports: Report[] = (
+    await getReports({ limit: 12, orders: '-publishedAt,-originalCreatedAt' })
+  ).contents;
+  // 生成するページの id (contentId) を返却
+  return reports.map((report) => ({
+    id: String(report.id),
+  }));
+}
+
+export default async function ReportDetailIndex({
+  params,
+}: {
+  params: { id: string };
+}) {
+  // 開催報告の詳細を取得
+  const report = await getReport(params.id);
+  // 投稿日時
+  const publishedAt = report.originalCreatedAt || report.publishedAt;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-between">
+      {/* Contents */}
+      <div className="mx-auto w-screen max-w-4xl px-8 py-20 max-sm:pt-14 sm:p-12 sm:py-20 md:p-24">
+        {/* 初めて参加される方へ */}
+        <div className="pb-5">
+          {/* 投稿日 */}
+          <p className="mb-2 text-xs text-gray-400">
+            {formatDate(publishedAt || '')}
+          </p>
+          {/* タイトル */}
+          <PageHeading label={report.title} className="text-left" />
+        </div>
+
+        {/* 記事詳細 */}
+        <ReportContent report={report} />
+      </div>
+    </main>
+  );
+}

--- a/src/components/layouts/TheHeader/TheHeader.tsx
+++ b/src/components/layouts/TheHeader/TheHeader.tsx
@@ -35,7 +35,8 @@ const TheHeader = () => {
         'relative inline-block',
         navigationPath === navMenuItemHref ||
           (navMenuItemHref === '/reports' &&
-            /^\/reports\/page\/\d+$/.test(navigationPath))
+            (/^\/reports\/page\/\d+$/.test(navigationPath) ||
+              /^\/reports\/[a-zA-Z0-9._-]+$/.test(navigationPath)))
           ? 'text-gray-400 after:absolute after:bottom-[-8px] after:left-0 after:h-[1px] after:w-full after:bg-gray-400'
           : undefined,
       );

--- a/src/components/pages/reports/ReportContent/ReportContent.tsx
+++ b/src/components/pages/reports/ReportContent/ReportContent.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React, { HTMLAttributes } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+import useFadeInOnScroll from '@/hooks/useFadeInOnScroll';
+import { parseToNextJSX } from '@/helpers/parseToNextJSX';
+
+import type { Report } from '@/features/report/types';
+
+type ReportContentProps = {
+  report: Report;
+} & HTMLAttributes<HTMLElement>;
+
+const ReportContent = ({ report, className }: ReportContentProps) => {
+  const { ref: sectionRef, fadeInClass } = useFadeInOnScroll(
+    {
+      additionalClasses: 'py-4',
+    },
+    undefined,
+  );
+
+  return (
+    <section ref={sectionRef} className={twMerge(fadeInClass, className)}>
+      {/* コンテンツ */}
+      <div>{parseToNextJSX(report.content)}</div>
+    </section>
+  );
+};
+
+export default ReportContent;

--- a/src/components/pages/reports/ReportContent/ReportContent.tsx
+++ b/src/components/pages/reports/ReportContent/ReportContent.tsx
@@ -17,7 +17,7 @@ const ReportContent = ({ report, className }: ReportContentProps) => {
     {
       additionalClasses: 'py-4',
     },
-    undefined,
+    0,
   );
 
   return (

--- a/src/features/report/api/getReport.ts
+++ b/src/features/report/api/getReport.ts
@@ -1,0 +1,18 @@
+import { microCMS } from '@/libs/microCMSClient';
+
+import type { MicroCMSQueries } from 'microcms-js-sdk';
+import type { Report } from '../types';
+
+export default async function getReport(
+  contentId: string,
+  queries?: MicroCMSQueries,
+) {
+  return await microCMS.get<Report>({
+    endpoint: 'reports',
+    contentId,
+    customRequestInit: {
+      next: { revalidate: 60 },
+    },
+    queries,
+  });
+}

--- a/src/features/report/api/getReports.ts
+++ b/src/features/report/api/getReports.ts
@@ -3,7 +3,7 @@ import { microCMS } from '@/libs/microCMSClient';
 import type { MicroCMSQueries } from 'microcms-js-sdk';
 import type { Report } from '../types';
 
-export default async function getNextEvents(queries?: MicroCMSQueries) {
+export default async function getReports(queries?: MicroCMSQueries) {
   return await microCMS.getList<Report>({
     endpoint: 'reports',
     customRequestInit: {

--- a/src/helpers/parseToNextJSX.tsx
+++ b/src/helpers/parseToNextJSX.tsx
@@ -1,0 +1,71 @@
+import Image from 'next/image';
+import parse, { domToReact, Element, Text } from 'html-react-parser';
+import Link from 'next/link';
+import { twMerge } from 'tailwind-merge';
+
+const isElement = (element: unknown): element is Element =>
+  element instanceof Element;
+const isText = (text: unknown): text is Text => text instanceof Text;
+
+export function parseToNextJSX(rawHtml: string) {
+  return parse(rawHtml, {
+    replace: (domNode) => {
+      if (domNode instanceof Element) {
+        const children = domNode.children.filter(
+          (node): node is Element | Text => isElement(node) || isText(node),
+        );
+
+        switch (domNode.name) {
+          // <h2>...</h2>
+          case 'h2':
+            return (
+              <p className={twMerge('mc-content-h2')}>{domToReact(children)}</p>
+            );
+          // <p>...</p>
+          case 'p':
+            return (
+              <p className={twMerge('mc-content-p')}>{domToReact(children)}</p>
+            );
+          // <figure>...</figure>
+          case 'figure':
+            return (
+              <figure className={twMerge('mc-content-figure')}>
+                {domToReact(children)}
+              </figure>
+            );
+          // <a>...</a>
+          case 'a': {
+            const atr = domNode.attribs;
+            // http が含まれる場合は a タグを使用
+            if (atr.href.indexOf('http') !== -1) {
+              return (
+                <a href={atr.href} target="_blank" rel="noopener noreferrer">
+                  {domToReact(children)}
+                </a>
+              );
+            }
+
+            // それ以外は Link タグに置換
+            return (
+              <Link href={domNode.attribs.href}>{domToReact(children)}</Link>
+            );
+          }
+          // <img>...</img>
+          case 'img': {
+            const atr = domNode.attribs;
+            return (
+              <Image
+                src={atr.src}
+                alt={atr.alt}
+                width={Number(atr.width)}
+                height={Number(atr.height)}
+              ></Image>
+            );
+          }
+          default:
+            break;
+        }
+      }
+    },
+  });
+}

--- a/src/helpers/parseToNextJSX.tsx
+++ b/src/helpers/parseToNextJSX.tsx
@@ -23,8 +23,11 @@ export function parseToNextJSX(rawHtml: string) {
             );
           // <p>...</p>
           case 'p':
+            // 空の場合は <br /> で改行, それ以外は domToReact(children)
             return (
-              <p className={twMerge('mc-content-p')}>{domToReact(children)}</p>
+              <p className={twMerge('mc-content-p')}>
+                {domNode.children.length === 0 ? <br /> : domToReact(children)}
+              </p>
             );
           // <figure>...</figure>
           case 'figure':

--- a/src/hooks/useFadeInOnScroll.ts
+++ b/src/hooks/useFadeInOnScroll.ts
@@ -6,10 +6,10 @@ type ClassConfig = {
   classNameAttr?: string;
 };
 
-const useFadeInOnScroll = <T extends HTMLElement = HTMLElement>({
-  additionalClasses = '',
-  classNameAttr = '',
-}: ClassConfig = {}) => {
+const useFadeInOnScroll = <T extends HTMLElement = HTMLElement>(
+  { additionalClasses = '', classNameAttr = '' }: ClassConfig = {},
+  threshold: number = 0.1,
+) => {
   const [isVisible, setIsVisible] = useState(false);
   const elementRef = useRef<T>(null);
 
@@ -26,7 +26,7 @@ const useFadeInOnScroll = <T extends HTMLElement = HTMLElement>({
       },
       {
         root: null, // ビューポートを監視
-        threshold: 0.1, // 要素の 10% が表示されたら発火
+        threshold, // 要素の 10% が表示されたら発火
       },
     );
 
@@ -39,6 +39,7 @@ const useFadeInOnScroll = <T extends HTMLElement = HTMLElement>({
         observer.unobserve(element);
       }
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Class を共通化


### PR DESCRIPTION
## 📝 関連する課題 / Related Issues

- #31

## ⛏ 変更内容 / Details of Changes

### ライブラリ導入

- html-react-parser を導入しました [d646fde74145faafbe835cf2f8fd141204655678]

### html-react-parser に付随する実装

- parse した DOM に当てる CSS Class を定義しました [abee8aeee56cd7441a805ace4c418642ef89323e]
- html-react-parser を使用し、DOM を parse して任意の形式に変換する関数を実装しました [3f8ccc2c2a1797e32420d8a83ac8b76dd5abf16b]

### 開催報告ページの実装

- 開催報告詳細取得を実装しました [98b7c780507c02a2cfa28bf8275ce6599510567f]
- 開催報告 report.contet をレンダリングするコンポーネントを実装しました [b562b451de5ed7f3bfbe7766be4d81bbeafb61da]
- 開催報告詳細ページの実装 (詳細表示まで) しました [33c1fa9c92b3926dcd0206a83de25731d28ade48]
- 改行が行われていない不具合を修正しました [42fcfb229a79540871c5211e481b8e48607e23cf]

### その他

- 引数に threshold を追加、スクロール 0 でフェードインする形になっていなかったため修正しました [7c5a7302e1db1a3501e7eee2209d3cdee26abe19 ce15513376d17120991a6920eb4f82db19f095f1]
- 開催報告詳細ページでも「開催報告」に下線が有効になるように修正しました [26d1414354d06b46c421369878dae74c21be8d31]
- 関数名を適切なものに修正しました [4cc8a727ec5d7b0741b78ac65afe26885c93c9e7]

以上になります。